### PR TITLE
FIX: Method compatibility when removing has_one relation

### DIFF
--- a/code/PickerFieldDeleteAction.php
+++ b/code/PickerFieldDeleteAction.php
@@ -16,7 +16,7 @@ class PickerFieldDeleteAction extends GridFieldDeleteAction {
 		$gridField->childObject->$childProperty = 0;
 		$gridField->childObject->write();
 		
-		$gridField->setList(null);
+		$gridField->setList(ArrayList::create());
 	}
 	
 	


### PR DESCRIPTION
`GridField::setList()` requires an `SS_List` instance: https://github.com/silverstripe/silverstripe-framework/blob/3.1/forms/gridfield/GridField.php#L199