### PR TITLE
Set the modelClass using the has_one relation name, not the class of cur...

### DIFF
--- a/code/HasOnePickerField.php
+++ b/code/HasOnePickerField.php
@@ -16,9 +16,14 @@ class HasOnePickerField extends PickerField {
 	 */
 	
 	public function __construct(DataObject $childObject, $name, $title = null, Object $currentHasOne, $linkExistingTitle = null, $searchContext = null) {
-		$modelClass = $currentHasOne->className;
-		$this->childObject = $childObject;
+		
+		$modelClass = $childObject->getRelationClass(str_replace('ID', '', $name));
+		if(!$modelClass) {
+			$modelClass = $currentHasOne->className;
+		}
+
 		$this->setModelClass($modelClass);
+		$this->childObject = $childObject;
 		
 		// convert the has_one relation getter to a DataList / SS_List
 		$dataList = $modelClass::get()->filter(array('ID' => $currentHasOne->ID));


### PR DESCRIPTION
Instead of setting the modelClass via the currentHasOne, get the class from the relation on the childObject instead, allowing parent classes to be used.